### PR TITLE
Backup Copy Job Issue

### DIFF
--- a/Make-VeeamWindowsScheduledTask/README.md
+++ b/Make-VeeamWindowsScheduledTask/README.md
@@ -44,7 +44,7 @@ if ((get-date).DayOfWeek -eq [System.DayOfWeek]::Friday -and ($week%2) -eq 1) {
 
 **Example:**
 
-![Script working](./Media/Screen.png)
+![Script working](./Media/screen.png)
 
 **Requires:** Veeam Backup & Replication v9
 

--- a/Make-VeeamWindowsScheduledTask/README.md
+++ b/Make-VeeamWindowsScheduledTask/README.md
@@ -44,7 +44,7 @@ if ((get-date).DayOfWeek -eq [System.DayOfWeek]::Friday -and ($week%2) -eq 1) {
 
 **Example:**
 
-![Script working](./Media/screen.png)
+![Script working](./Media/Screen.png)
 
 **Requires:** Veeam Backup & Replication v9
 


### PR DESCRIPTION
Last session is always open, causing the report to display fails. This should validate itself if progress is at 100%, the job is idle and no VMs have failed/warning or other status on them.