### PR TITLE
Update import-vcc-backups.ps1

### DIFF
--- a/VCC-Import-Backups/import-vcc-backups.ps1
+++ b/VCC-Import-Backups/import-vcc-backups.ps1
@@ -1,8 +1,9 @@
-# 
+#
 # Import all Veeam Cloud Connect backups
 #
 # v 1.0 - Luca Dell'Oca
 # v 1.1 - Preben Berg - optimized for loops
+# v 1.2 - Andrea Borella - minor changes for v9.5 compatibility
 #
 # Run this script on the Veeam server
 #
@@ -10,7 +11,7 @@
 # 1. retrieves the list of repositories, first windows than # linux
 # 2. lists recursively all the existing backup chains (.vbm files)
 # 3. imports all the chains into the VBR server
-# 
+#
 # To use the SSH commands, you need to have Posh-SSH module installed.
 # To install the module, you need to run this code on Windows 10, or
 # have Windows Management Framework 5.0 installed. Once ready, run:
@@ -24,21 +25,21 @@ asnp VeeamPSSnapIn -ErrorAction SilentlyContinue
 ## Process Windows repositories
 
 # Retrieve the list of windows repositories
-$winrepos = Get-VBRBackupRepository | where Type -eq "WinLocal"
 
-ForEach ($winrepo in $winrepos) {
+ForEach ($winrepo in Get-VBRBackupRepository | where Type -eq "WinLocal") {
     $winreponame = $winrepo.GetHost().Name;
 
     #obtain the full unc path of the repository to be passed to get-childitem
-    $winrepopath = "\\{0}\{1}" -f ($winreponame, $winrepo.Path.Replace(":", "$"));
+    $winrepopath = "\\{0}\{1}" -f ($winreponame, $winrepo.FriendlyPath.Replace(":", "$"));
 
     #browse recursively the repository to find any backup chain, by identifying all the .vbm files
-    $winvbms = Get-ChildItem -Path $winrepopath -Filter "*.vbm" -Recurse -ErrorAction SilentlyContinue -Force | `
-        Select-Object FullName, @{ Name="LocalPath"; Expression={$_.FullName.Replace("$",":").Replace("\\$winreponame\","")} }
+    $winvbms = Get-ChildItem -Path $winrepopath -Filter "*.vbm" -Recurse -ErrorAction SilentlyContinue -Force
 
     # Import the backup chains into Veeam server
-    ForEach ($winvbm in $winvbms) {
-        $winrepo.GetHost() | Import-VBRBackup -Filename $winvbm.LocalPath
+    ForEach ($vbm in $winvbms) {
+        $path=$vbm.DirectoryName
+        $vbmfile=$vbm.Name
+        $winrepo.GetHost() | Import-VBRBackup -Filename $path\$vbmfile
     }
 }
 
@@ -53,7 +54,7 @@ if (Get-Command -Name "New-SSHSession" -ErrorAction SilentlyContinue) {
         $linuxreponame = $linuxrepo.GetHost().Name;
 
         # Login via ssh into the linux repository (interactive username and password request)
-        New-SSHSession -ComputerName $linuxreponame -Credential (Get-Credential) -AcceptKey
+        New-SSHSession -ComputerName $linuxreponame -Credential (Get-Credential) -AcceptKey
 
         # find all .vbm files in the linux repository, output has full path
         $linuxvbms = Invoke-SSHCommand -SessionId 0 -Command "find / -type f -name *.vbm" | select -ExpandProperty Output


### PR DESCRIPTION
modified import of vbm files in windows repositories.
the method $repo.Path() has been replaced by $repo.FriendlyPath() in VBR 9.5