### PR TITLE
Update Invoke-UnityNASBackup.ps1

### DIFF
--- a/BR-NASBackup4Unity/Invoke-UnityNASBackup.ps1
+++ b/BR-NASBackup4Unity/Invoke-UnityNASBackup.ps1
@@ -215,7 +215,7 @@ PROCESS {
         $uri = "https://" + $UnitySession.Server + $resourceurl
 
         # Invoke the RestAPI call
-        $objSnapShare = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Body $json -Websession $UnitySession.Websession -Headers $UnitySession.headers -Method POST -TimeoutSec 6000
+        $objSnapShare = Invoke-WebRequest -Uri $URI -ContentType "application/json" -Body $json -Websession $UnitySession.Websession -Headers $UnitySession.headers -Method POST -TimeoutSec 6000 -UseBasicParsing
         $objSnapShareContent = $objSnapShare.Content | convertfrom-json
         $SnapID = $objSnapShareContent.content.id
         Write-Log -Info "New cifs share named $SnapShotName created, ID: $SnapID" -Status Info


### PR DESCRIPTION
# Pull Request Template

By contributing, you agree that your contributions will be licensed under the projects original open source license.

## Description

The following Error can occure:
The response content cannot be parsed because the Internet Explorer engine is not available, or Inte
rnet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.

Fixes # (issue)

Added -UseBasicParsing to the Invoke-WebRequest command in the create-NewBackupShare function.

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

### Checklist (check all applicable):

* [ ] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in _hard to understand_ areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
