### PR TITLE
Add VBO-AddDefenderExclusions script

### DIFF
--- a/VBO-AddDefenderExclusions/README.md
+++ b/VBO-AddDefenderExclusions/README.md
@@ -1,0 +1,24 @@
+# VBO-AddDefenderExclusions
+
+## Project Notes
+
+**Author:** Stefan Zimmermann (Veeam Software)
+
+**Function:** Adds VBO anti-virus exclusions based on [KB3074](https://www.veeam.com/kb3074) to the
+Windows Defender on the local VBO installation. Does also include configured local repository paths.
+
+**Usage:** Run script on the VBO server.
+
+**Restrictions**: Does not support external proxy servers for now.
+
+## VeeamHub
+Veeamhub projects are community driven projects, and are not created by Veeam R&D nor validated by Veeam Q&A. They are maintained by community members which might be or not be Veeam employees. 
+
+## Distributed under MIT license
+Copyright (c) 2020 VeeamHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/VBO-AddDefenderExclusions/VBO-AddDefenderExclusions.ps1
+++ b/VBO-AddDefenderExclusions/VBO-AddDefenderExclusions.ps1
@@ -1,0 +1,58 @@
+<#
+.SYNOPSIS
+    Add Windows Defender Exclusions for Veeam Backup for Microsoft Office 365
+.DESCRIPTION
+    Add path exclusions to the directories which are scanned by Windows Defender for VBO based on 
+    https://www.veeam.com/kb3074.
+    Does resolve the repository paths automatically and adds them, too.
+.EXAMPLE
+    PS C:\>VBO-AddDefenderExclusions.ps1
+    Add exclusions on the local server
+.INPUTS
+    NONE
+.OUTPUTS
+    Print a list of excluded directories
+.NOTES
+    Written by Stefan Zimmermann <stefan.zimmermann@veeam.com>
+
+    v1.0.0  27.04.2020    Initial version for local VBO management server and it's repos
+
+    - Requires Veeam.Archiver.PowerShell module on the system.
+    - Script can run multiple times as exclusions will be overwritten if they exist already.
+#>
+#requires -modules Veeam.Archiver.PowerShell
+
+Import-Module Veeam.Archiver.PowerShell
+
+$vbo_exclusions = @(
+    "${env:ProgramFiles}\Veeam",
+    "${env:ProgramFiles(x86)}\Veeam",
+    "${env:ProgramFiles}\Common Files\Veeam",
+    "${env:ProgramFiles(x86)}\Common Files\Veeam",
+    "${env:windir}\Veeam",
+    "${env:ProgramData}\Veeam"
+)
+
+$proxy_exclusions = @(
+    "${env:windir}\Veeam",
+    "${env:ProgramData}\Veeam"
+)
+
+$local_proxy = Get-VBOProxy -Hostname $env:COMPUTERNAME
+
+# Add local repository paths to VBO exclusions
+Get-VBORepository -Proxy $local_proxy | % { $vbo_exclusions += $_.Path }
+
+# Add exclusions to local VBO instance
+
+foreach ($exclusion in $vbo_exclusions) {
+    try {
+        Add-MpPreference -ExclusionPath $exclusion
+        Write-Host -BackgroundColor DarkGreen "Excluding $exclusion"
+    } catch {
+        Write-Host -BackgroundColor Red "Error excluding $exclusion"
+    }    
+}
+
+# TODO: Add exclusions on external proxy servers via remote PowerShell if possible
+# $other_proxies = Get-VBOProxy | ? { $_.Hostname -ne $env:COMPUTERNAME }


### PR DESCRIPTION
Signed-off-by: Stefan Zimmermann <stefan.zimmermann@veeam.com>

# Pull Request Template

By contributing, you agree that your contributions will be licensed under the projects original open source license.

## Description

A script to add VBO anti-virus exclusions to Windows Defender as suggested in KB3074. Helps to add the exclusions quickly on freshly installed systems.

### Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How Has This Been Tested?

Multiple tests on my own WS2019 demo system - script can run multiple times.
Can be called on every VBO system with the management role installed and added exclusions are put on stdout and will be visible in the exclusion list of Windows Defender.

### Checklist (check all applicable):

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in _hard to understand_ areas
* [x] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
