### PR TITLE
VMware Cloud Director usage script for Veeam backups

### DIFF
--- a/VCD-OrgUsageReport/Get-VcdOrgUsage.ps1
+++ b/VCD-OrgUsageReport/Get-VcdOrgUsage.ps1
@@ -47,7 +47,7 @@
 
 	Description
 	-----------
-	Verbose output is support
+	Verbose output is supported
 
 .NOTES
 	NAME:  Get-VcdOrgUsage.ps1

--- a/VCD-OrgUsageReport/Get-VcdOrgUsage.ps1
+++ b/VCD-OrgUsageReport/Get-VcdOrgUsage.ps1
@@ -51,7 +51,7 @@
 
 .NOTES
 	NAME:  Get-VcdOrgUsage.ps1
-	VERSION: 1.1
+	VERSION: 1.2
 	AUTHOR: Chris Arceneaux
 	TWITTER: @chris_arceneaux
 	GITHUB: https://github.com/carceneaux
@@ -248,8 +248,6 @@ if ($IncludeAllVcdBackups) {
 
     # Looping through Non-VSSP backups
     foreach ($backup in $nonSelfServiceVcdBackups) {
-        # Setting repository information
-        $repo = $repos | Where-Object {$_.Id -eq $backup.RepositoryId}
         # Retrieving backup files
         $storages = $backup.GetAllStorages()
         # Looping through backup objects
@@ -275,13 +273,18 @@ if ($IncludeAllVcdBackups) {
                         organizationName = $orgName;
                         orgVdcRef        = $vcdVAppLocation.OrgVdcRef;
                         orgVdcName       = $orgVdcName;
-                        repositoryId     = $repo.Id;
-                        repositoryName   = $repo.Name;
+                        repositoryId     = $null;
+                        repositoryName   = $null;
                         protectedVms     = 0;
                         quotaId          = $null;
                         quotaGb          = $null;
                         usedSpace        = 0
                     }
+                }
+                # Nulling Backup Repository as it might not match VSSP backups
+                else {
+                    $orgReports[$orgName][$orgVdcName].repositoryId = $null
+                    $orgReports[$orgName][$orgVdcName].repositoryName = $null
                 }
                 if ($object.Type -eq "VM") {
                     if ($object.Id -notin $knownVmIds) {
@@ -312,6 +315,12 @@ if ($IncludeAllVcdBackups) {
                         usedSpace        = 0
                     }
                 }
+                # Nulling Backup Repository as it might not match VSSP backups
+                else {
+                    $orgReports[$orgName].repositoryId = $null
+                    $orgReports[$orgName].repositoryName = $null
+                }
+
                 if ($object.Type -eq "VM") {
                     if ($object.Id -notin $knownVmIds) {
                         $orgReports[$orgName].protectedVms += 1

--- a/VCD-OrgUsageReport/Get-VcdOrgUsage.ps1
+++ b/VCD-OrgUsageReport/Get-VcdOrgUsage.ps1
@@ -51,7 +51,7 @@
 
 .NOTES
 	NAME:  Get-VcdOrgUsage.ps1
-	VERSION: 1.0
+	VERSION: 1.1
 	AUTHOR: Chris Arceneaux
 	TWITTER: @chris_arceneaux
 	GITHUB: https://github.com/carceneaux
@@ -240,7 +240,7 @@ foreach ($item in $vcdOrgItems) {
 if ($IncludeAllVcdBackups) {
     Write-Verbose "Flag specified...including usage for Non-VSSP Backups as well..."
     # Retrieving all VCD backups
-    $allVcdBackups = Get-VBRBackup | Where-Object -FilterScript { $_.BackupPlatform.ToString() -eq "EVcd" }
+    $allVcdBackups = [Veeam.Backup.Core.CBackup]::GetAll() | Where-Object -FilterScript { $_.BackupPlatform.ToString() -eq "EVcd" }
     
     # Separating out VSSP backups vs backups created directly on the backup server by the provider
     $nonSelfServiceVcdBackups = $allVcdBackups | Where-Object -FilterScript { $_.Id -notin $selfServiceBackupIds }
@@ -338,16 +338,16 @@ if ($AggregateByOrgVdc) {
     foreach ($orgReportEntry in $orgReports.GetEnumerator()) {
         foreach ($orgVdcReportEntry in $orgReportEntry.Value.GetEnumerator()) {
             $usage.Add([PSCustomObject]@{
-                    VcdId        = $orgVdcReportEntry.Value.vcdId;
+                    #VcdId        = $orgVdcReportEntry.Value.vcdId;
                     VCD          = $orgVdcReportEntry.Value.vcdName;
-                    OrganizationRef = $orgVdcReportEntry.Value.organizationRef;
+                    #OrganizationRef = $orgVdcReportEntry.Value.organizationRef;
                     Organization = $orgReportEntry.Key;
-                    OrgVdcRef    = $orgVdcReportEntry.Value.orgVdcRef
+                    #OrgVdcRef    = $orgVdcReportEntry.Value.orgVdcRef
                     OrgVDC       = $orgVdcReportEntry.Key;
-                    RepositoryId = $orgVdcReportEntry.Value.repositoryId;
+                    #RepositoryId = $orgVdcReportEntry.Value.repositoryId;
                     Repository   = $orgVdcReportEntry.Value.repositoryName;
                     ProtectedVMs = $orgVdcReportEntry.Value.protectedVms;
-                    QuotaId      = $orgVdcReportEntry.Value.quotaId;
+                    #QuotaId      = $orgVdcReportEntry.Value.quotaId;
                     QuotaGB      = $orgVdcReportEntry.Value.quotaGb;
                     UsedSpaceGB  = [math]::round($orgVdcReportEntry.Value.usedSpace / 1Gb, 2) #convert bytes to GB
                 })
@@ -358,14 +358,14 @@ if ($AggregateByOrgVdc) {
 else {
     foreach ($orgReportEntry in $orgReports.GetEnumerator()) {
         $usage.Add([PSCustomObject]@{
-                VcdId        = $orgReportEntry.Value.vcdId;
+                #VcdId        = $orgReportEntry.Value.vcdId;
                 VCD          = $orgReportEntry.Value.vcdName;
-                OrganizationRef = $orgReportEntry.Value.organizationRef;
+                #OrganizationRef = $orgReportEntry.Value.organizationRef;
                 Organization = $orgReportEntry.Key;
-                RepositoryId = $orgReportEntry.Value.repositoryId;
+                #RepositoryId = $orgReportEntry.Value.repositoryId;
                 Repository   = $orgReportEntry.Value.repositoryName;
                 ProtectedVMs = $orgReportEntry.Value.protectedVms;
-                QuotaId      = $orgReportEntry.Value.quotaId;
+                #QuotaId      = $orgReportEntry.Value.quotaId;
                 QuotaGB      = $orgReportEntry.Value.quotaGb;
                 UsedSpaceGB  = [math]::round($orgReportEntry.Value.usedSpace / 1Gb, 2) #convert bytes to GB
             })

--- a/VCD-OrgUsageReport/Get-VcdOrgUsage.ps1
+++ b/VCD-OrgUsageReport/Get-VcdOrgUsage.ps1
@@ -307,8 +307,8 @@ if ($IncludeAllVcdBackups) {
                         vcdName          = ($vcdItems | Where-Object { $_.Id -eq $vcdVAppLocation.VcdInstanceDbId}).Name;
                         organizationRef  = $vcdVAppLocation.OrgRef;
                         organizationName = $orgName;
-                        repositoryId     = $repo.Id;
-                        repositoryName   = $repo.Name;
+                        repositoryId     = $null;
+                        repositoryName   = $null;
                         protectedVms     = 0;
                         quotaId          = $null;
                         quotaGb          = $null;

--- a/VCD-OrgUsageReport/Get-VcdOrgUsage.ps1
+++ b/VCD-OrgUsageReport/Get-VcdOrgUsage.ps1
@@ -239,8 +239,8 @@ foreach ($item in $vcdOrgItems) {
 # Retrieving ALL VCD backups usage (if specified). Not just VSSP backups.
 if ($IncludeAllVcdBackups) {
     Write-Verbose "Flag specified...including usage for Non-VSSP Backups as well..."
-    # Retrieving all VCD backups
-    $allVcdBackups = [Veeam.Backup.Core.CBackup]::GetAll() | Where-Object -FilterScript { $_.BackupPlatform.ToString() -eq "EVcd" }
+    # Retrieving all VCD backups (excluding VCD Replication)
+    $allVcdBackups = [Veeam.Backup.Core.CBackup]::GetAll() | Where-Object -FilterScript { ($_.BackupPlatform.ToString() -eq "EVcd") -and (!$_.IsVcdReplica) }
     
     # Separating out VSSP backups vs backups created directly on the backup server by the provider
     $nonSelfServiceVcdBackups = $allVcdBackups | Where-Object -FilterScript { $_.Id -notin $selfServiceBackupIds }

--- a/VCD-OrgUsageReport/Get-VcdOrgUsage.ps1
+++ b/VCD-OrgUsageReport/Get-VcdOrgUsage.ps1
@@ -1,0 +1,319 @@
+<#
+.SYNOPSIS
+	Veeam backup usage for VMware Cloud Director Organizations
+
+.DESCRIPTION
+    The script retrieves Veeam backup usage for VMware Cloud Director (VCD) Organizations. The usage data can be aggregated on the Organization-level or the Org VDC-level.
+	
+.PARAMETER AggregateByOrgVdc
+	Used to enable data aggregation on the Organization VDC-level. Useful when backups for different Org VDCs are billed differently. If not specified, script will aggregate at the Organization-level.
+
+.PARAMETER IncludeAllVcdBackups
+	Used to include usage statistics for all VCD backups. If not specified, usage will be limited to self-service backups, created by the [Veeam Self-Service Portal (VSSP) for VCD](https://helpcenter.veeam.com/docs/backup/em/em_managing_vms_in_vcd_org.html?ver=110).
+
+.OUTPUTS
+	Get-VcdOrgUsage returns a PowerShell Object containing all data
+
+.EXAMPLE
+	Get-VcdOrgUsage.ps1
+
+	Description
+	-----------
+	Returns usage information for all backups created/managed by the VSSP aggregated by VCD Organization
+
+.EXAMPLE
+	Get-VcdOrgUsage.ps1 -AggregateByOrgVdc
+
+	Description
+	-----------
+	Returns usage information for all backups created/managed by the VSSP aggregated by VCD Organization VDC
+
+.EXAMPLE
+	Get-VcdOrgUsage.ps1 -IncludeAllVcdBackups
+
+	Description
+	-----------
+	Returns usage information for all VCD backups whether created by the VSSP or directly on the backup server by the provider aggregated by VCD Organization
+
+.EXAMPLE
+	Get-VcdOrgUsage.ps1 -AggregateByOrgVdc -IncludeAllVcdBackups
+
+	Description
+	-----------
+	Returns usage information for all VCD backups whether created by the VSSP or directly on the backup server by the provider aggregated by VCD Organization VDC
+
+.EXAMPLE
+	Get-VcdOrgUsage.ps1 -Verbose
+
+	Description
+	-----------
+	Verbose output is support
+
+.NOTES
+	NAME:  Get-VcdOrgUsage.ps1
+	VERSION: 1.0
+	AUTHOR: Chris Arceneaux
+	TWITTER: @chris_arceneaux
+	GITHUB: https://github.com/carceneaux
+
+.LINK
+	https://arsano.ninja/
+
+#>
+[CmdletBinding()]
+param(
+    [switch]$AggregateByOrgVdc,
+    [switch]$IncludeAllVcdBackups
+)
+
+# All VCD VMs exist beneath a vApp. This function returns the source vApp location for the vApp/VM specified.
+function Get-VcdVAppLocation {
+    [CmdletBinding()]
+
+    param(
+        [Parameter(Mandatory = $true)]
+        [Veeam.Backup.Core.CBackup]
+        $Backup,
+
+        [Parameter(Mandatory = $true,
+            ParameterSetName = "VM")]
+        [guid]
+        $VMObjectId,
+
+        [Parameter(Mandatory = $true,
+            ParameterSetName = "vApp")]
+        [guid]
+        $VAppObjectId
+    )
+
+    if ($PSCmdlet.ParameterSetName -eq "VM") {
+        $vmOib = $Backup.FindLastOib($VMObjectId)
+        $vAppOib = $vmOib.FindParent()
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq "vApp") {
+        $vAppOib = $Backup.FindLastOib($VAppObjectId)
+    }
+
+    return $vAppOib.AuxData.OrigVApp.VCloudVAppLocation
+}
+
+# Initializing variables
+if ($IncludeAllVcdBackups) {
+    $selfServiceBackupIds = New-Object -TypeName System.Collections.Generic.List[guid]
+}
+$orgReports = @{}
+$knownVmIds = New-Object -TypeName System.Collections.Generic.List[guid]
+
+# Retrieving all VCD Organization items from Veeam
+$vcdOrgItems = Find-VBRvCloudEntity | Where-Object -FilterScript { $_.Type -eq "Organization" }
+Write-Verbose "Retrieved $($vcdOrgItems.count) Organizations from Veeam"
+
+# Retrieving all Veeam repositories
+$repos = Get-VBRBackupRepository
+$repos += Get-VBRBackupRepository -ScaleOut
+Write-Verbose "Retrieved $($repos.count) Repositories from Veeam"
+
+# Looping through all VCD Organization items
+foreach ($item in $vcdOrgItems) {
+    Write-Verbose "$($item.Name): Retrieving VSSP Backups for Organization"
+    # Creating CVcdOrganization object. Required for subsequent API call.
+    $vcdOrg = New-Object -TypeName Veeam.Backup.Model.CVcdOrganization `
+        -ArgumentList $item.VcdId, $item.VcdRef, $item.Name
+    
+    # Looping through all Veeam repositories
+    foreach ($repo in $repos){
+        Write-Verbose "$($item.Name): Searching '$($repo.Name)' for VSSP quota..."
+        # Retrieving VSSP quota if exists
+        $orgQuotaId = [Veeam.Backup.Core.CJobQuota]::FindByOrganization($vcdOrg, $repo.Id.Guid).Id
+        
+        # If VSSP quota exists
+        if ($orgQuotaId) {
+            Write-Verbose "$($item.Name): VSSP quota found: $orgQuotaId"
+            $orgBackupIds = [Veeam.Backup.DBManager.CDBManager]::Instance.Backups.FindBackupsByQuotaIds($orgQuotaId).Id
+            # Aggregate by Org VDC
+            if ($AggregateByOrgVdc) {
+                Write-Verbose "$($item.Name): Aggregating by Org VDC..."
+                # Looping through backups
+                foreach ($backupId in $orgBackupIds) {
+                    if ($IncludeAllVcdBackups) {
+                        $selfServiceBackupIds.Add($backupId)
+                    }
+
+                    # Retrieving backup using backup ID
+                    $backup = [Veeam.Backup.Core.CBackup]::Get($backupId)
+                    
+                    # Retrieving backup files
+                    $storages = $backup.GetAllStorages()
+
+                    # Looping through backup objects
+                    foreach ($object in $backup.GetObjects()) {
+                        if ($object.Type -eq "VM") {
+                            $vcdVAppLocation = Get-VcdVAppLocation -Backup $backup -VMObjectId $object.Id
+                        }
+                        elseif ($object.Type -eq "NfcDir") {
+                            $vcdVAppLocation = Get-VcdVAppLocation -Backup $backup -VAppObjectId $object.Id
+                        }
+                        $orgVdcName = $vcdVAppLocation.OrgVdcName
+                        if (!$orgReports.Contains($vcdOrg.OrgName)) {
+                            $orgReports[$vcdOrg.OrgName] = @{}
+                        }
+                        if (!$orgReports[$vcdOrg.OrgName].Contains($orgVdcName)) {
+                            $orgReports[$vcdOrg.OrgName][$orgVdcName] = [PSCustomObject]@{
+                                protectedVms = 0;
+                                usedSpace    = 0
+                            }
+                        }
+                        if ($object.Type -eq "VM") {
+                            if ($object.Id -notin $knownVmIds) {
+                                $orgReports[$vcdOrg.OrgName][$orgVdcName].protectedVms += 1
+                                $knownVmIds.Add($object.Id)
+                            }
+                        }
+                        # Retrieving size for all backup files
+                        $sizePerObjectStorage = ($storages | Where-Object -FilterScript { $_.ObjectId -eq $object.Id }).Stats.BackupSize
+                        # Summing up size for all backup files per object
+                        foreach ($size in $sizePerObjectStorage) {
+                            $orgReports[$vcdOrg.OrgName][$orgVdcName].usedSpace += $size
+                        }
+                    }
+                }
+            }
+            # Aggregate by VCD Organization
+            else {
+                Write-Verbose "$($item.Name): Aggregating by Organization..."
+                # Looping through backups
+                foreach ($backupId in $orgBackupIds) {
+                    if ($IncludeAllVcdBackups) {
+                        $selfServiceBackupIds.Add($backupId)
+                    }
+
+                    # Retrieving backup using backup ID
+                    $backup = [Veeam.Backup.Core.CBackup]::Get($backupId)
+                    if (!$orgReports.Contains($vcdOrg.OrgName)) {
+                        $orgReports[$vcdOrg.OrgName] = [PSCustomObject]@{
+                            protectedVms = 0;
+                            usedSpace    = 0
+                        }
+                    }
+                    # Looping through backup objects
+                    foreach ($object in $backup.GetObjects() | Where-Object -FilterScript { $_.Type -eq "VM" }) {
+                        if ($object.Id -notin $knownVmIds) {
+                            $orgReports[$vcdOrg.OrgName].protectedVms += 1
+                            $knownVmIds.Add($object.Id)
+                        }
+                    }
+                    # Retrieving size for all backup files
+                    $sizePerStorage = $backup.GetAllStorages().Stats.BackupSize
+                    # Summing up size for all backup files per object
+                    foreach ($size in $sizePerStorage) {
+                        $orgReports[$vcdOrg.OrgName].usedSpace += $size
+                    }
+                }
+            }
+        }
+    }
+}
+
+# Including ALL VCD backups if specified. Not just VSSP backups.
+if ($IncludeAllVcdBackups) {
+    Write-Verbose "Flag specified...including usage for Non-VSSP Backups as well..."
+    # Retrieving all VCD backups
+    $allVcdBackups = Get-VBRBackup | Where-Object -FilterScript { $_.BackupPlatform.ToString() -eq "EVcd" }
+    
+    # Separating out VSSP backups vs backups created directly on the backup server by the provider
+    $nonSelfServiceVcdBackups = $allVcdBackups | Where-Object -FilterScript { $_.Id -notin $selfServiceBackupIds }
+    Write-Verbose "Non-VSSP Backups found: $($nonSelfServiceVcdBackups.count)"
+
+    # Looping through backups
+    foreach ($backup in $nonSelfServiceVcdBackups) {
+        # Retrieving backup files
+        $storages = $backup.GetAllStorages()
+        # Looping through backup objects
+        foreach ($object in $backup.GetObjects()) {
+            if ($object.Type -eq "VM") {
+                $vcdVAppLocation = Get-VcdVAppLocation -Backup $backup -VMObjectId $object.Id
+            }
+            elseif ($object.Type -eq "NfcDir") {
+                $vcdVAppLocation = Get-VcdVAppLocation -Backup $backup -VAppObjectId $object.Id
+            }
+            $orgName = $vcdVAppLocation.OrgName
+            # Aggregate by Org VDC
+            if ($AggregateByOrgVdc) {
+                $orgVdcName = $vcdVAppLocation.OrgVdcName
+                if (!$orgReports.Contains($orgName)) {
+                    $orgReports[$orgName] = @{}
+                }
+                if (!$orgReports[$orgName].Contains($orgVdcName)) {
+                    $orgReports[$orgName][$orgVdcName] = [PSCustomObject]@{
+                        protectedVms = 0;
+                        usedSpace    = 0
+                    }
+                }
+                if ($object.Type -eq "VM") {
+                    if ($object.Id -notin $knownVmIds) {
+                        $orgReports[$orgName][$orgVdcName].protectedVms += 1
+                        $knownVmIds.Add($object.Id)
+                    }
+                }
+                # Retrieving size for all backup files
+                $sizePerObjectStorage = ($storages | Where-Object -FilterScript { $_.ObjectId -eq $object.Id }).Stats.BackupSize
+                # Summing up size for all backup files per object
+                foreach ($size in $sizePerObjectStorage) {
+                    $orgReports[$orgName][$orgVdcName].usedSpace += $size
+                }
+            }
+            # Aggregate by VCD Organization
+            else {
+                if (!$orgReports.Contains($orgName)) {
+                    $orgReports[$orgName] = [PSCustomObject]@{
+                        protectedVms = 0;
+                        usedSpace    = 0
+                    }
+                }
+                if ($object.Type -eq "VM") {
+                    if ($object.Id -notin $knownVmIds) {
+                        $orgReports[$orgName].protectedVms += 1
+                        $knownVmIds.Add($object.Id)
+                    }
+                }
+                # Retrieving size for all backup files
+                $sizePerObjectStorage = ($storages | Where-Object -FilterScript { $_.ObjectId -eq $object.Id }).Stats.BackupSize
+                # Summing up size for all backup files per object
+                foreach ($size in $sizePerObjectStorage) {
+                    $orgReports[$orgName].usedSpace += $size
+                }
+            }
+        }
+    }
+}
+
+# Initializing output object
+$usage = New-Object -TypeName System.Collections.Generic.List[PSCustomObject]
+
+# Per-Org VDC: Populating output object with usage statistics
+Write-Verbose "Preparing usage for output..."
+if ($AggregateByOrgVdc) {
+    foreach ($orgReportEntry in $orgReports.GetEnumerator()) {
+        foreach ($orgVdcReportEntry in $orgReportEntry.Value.GetEnumerator()) {
+            $usage.Add([PSCustomObject]@{
+                    Organization = $orgReportEntry.Key;
+                    VDC          = $orgVdcReportEntry.Key;
+                    ProtectedVMs = $orgVdcReportEntry.Value.protectedVms
+                    UsedSpaceGB  = [math]::round($orgVdcReportEntry.Value.usedSpace / 1Gb, 2) #convert bytes to GB
+                })
+        }
+    }
+}
+# Per-Organization: Populating output object with usage statistics
+else {
+    foreach ($orgReportEntry in $orgReports.GetEnumerator()) {
+        $usage.Add([PSCustomObject]@{
+                Organization = $orgReportEntry.Key;
+                ProtectedVMs = $orgReportEntry.Value.protectedVms;
+                UsedSpaceGB  = [math]::round($orgReportEntry.Value.usedSpace / 1Gb, 2) #convert bytes to GB
+            })
+    }
+}
+
+# Outputting usage statistics
+return $usage

--- a/VCD-OrgUsageReport/README.md
+++ b/VCD-OrgUsageReport/README.md
@@ -21,12 +21,16 @@ The scope of the usage returned is also customizable. It can be limited to self-
 
 ## Known Issues
 
-`-AggregateByOrgVdc` and `-IncludeAllVcdBackups` parameters REQUIRE the backups to be stored in per-VM backup files ("Use per-VM backup files" option in advanced settings of a backup repository). This is because the size of the backups is calculated using backup files, and it's impossible to reliably attribute per-VM consumption to the correct Organization/Org VDC when a backup file contains several VMs from different Organizations/Org VDCs.
+* *There are no known issues for VSSP backup usage.*
+* `-IncludeAllVcdBackups` does not include VCD Replication job storage usage.
+* `-IncludeAllVcdBackups` reports usage correctly but repository specified may be incorrect.
 
 ## Requirements
 
 * Veeam Backup & Replication 11
   * _Does not work with previous versions_
+* Backups must be stored in a Backup Repository with [per-machine backup files enabled](https://helpcenter.veeam.com/docs/backup/vsphere/repository_repository.html?ver=110)
+  * This is because the size of the backups is calculated using backup files, and it's impossible to reliably attribute per-machine consumption to the correct Organization/Org VDC when a backup file contains several VMs from different Organizations/Org VDCs.
 
 ## Usage
 

--- a/VCD-OrgUsageReport/README.md
+++ b/VCD-OrgUsageReport/README.md
@@ -22,8 +22,9 @@ The scope of the usage returned is also customizable. It can be limited to self-
 ## Known Issues
 
 * *There are no known issues for VSSP backup usage.*
-* `-IncludeAllVcdBackups` does not include VCD Replication job storage usage.
-* `-IncludeAllVcdBackups` reports usage correctly but repository specified may be incorrect.
+* Non-VSSP Backup usage:
+  * `-IncludeAllVcdBackups` does not include VCD Replication job usage
+  * `-IncludeAllVcdBackups` usage does not specify Backup Repository
 
 ## Requirements
 
@@ -35,3 +36,11 @@ The scope of the usage returned is also customizable. It can be limited to self-
 ## Usage
 
 Get-Help .\Get-VcdOrgUsage.ps1 -Full
+
+***NOTE:*** If you'd like the following additional metrics, you can uncomment corresponding lines 350-379 in the script:
+
+* VCD UID
+* Organization UID
+* Org VDC UID
+* Backup Repository UID
+* VSSP Quota UID

--- a/VCD-OrgUsageReport/README.md
+++ b/VCD-OrgUsageReport/README.md
@@ -1,0 +1,33 @@
+# Veeam Usage Report for VMware Cloud Director
+
+## Author
+
+* Chris Arceneaux (@chris_arceneaux)
+
+A big thanks to Yuri Sukhov ([@wombatairlines](https://twitter.com/wombatairlines))! I used his [code](https://github.com/wombatonfire/veeam-powershell/tree/master/New-OrgBackupReport) as a starting point for this project.
+
+## Function
+
+The script retrieves Veeam backup usage for VMware Cloud Director (VCD) Organizations. For each organization, the following is provided:
+
+* Total number of VMs in backups
+* Total amount of space used in repositories
+
+The usage data can be aggregated on the Organization-level or the Org VDC-level. This is useful when backups for different Org VDCs are billed differently.
+
+The scope of the usage returned is also customizable. It can be limited to self-service backups, created by the [Veeam Self-Service Portal (VSSP) for VCD](https://helpcenter.veeam.com/docs/backup/em/em_managing_vms_in_vcd_org.html?ver=110), or it can also include backups created directly on the backup server by the provider.
+
+***NOTE:*** Before using this script in a production environment, I recommend you verify that numbers match up to your environment. This script uses undocumented API calls so it's subject to change.
+
+## Known Issues
+
+`-AggregateByOrgVdc` and `-IncludeAllVcdBackups` parameters REQUIRE the backups to be stored in per-VM backup files ("Use per-VM backup files" option in advanced settings of a backup repository). This is because the size of the backups is calculated using backup files, and it's impossible to reliably attribute per-VM consumption to the correct Organization/Org VDC when a backup file contains several VMs from different Organizations/Org VDCs.
+
+## Requirements
+
+* Veeam Backup & Replication 11
+  * _Does not work with previous versions_
+
+## Usage
+
+Get-Help .\Get-VcdOrgUsage.ps1 -Full


### PR DESCRIPTION
# Pull Request Template

By contributing, you agree that your contributions will be licensed under the projects original open source license.

## Description

The script retrieves Veeam backup usage for VMware Cloud Director (VCD) Organizations. For each organization, the following is provided:

* Total number of VMs in backups
* Total amount of space used in repositories

The usage data can be aggregated on the Organization-level or the Org VDC-level. This is useful when backups for different Org VDCs are billed differently.

The scope of the usage returned is also customizable. It can be limited to self-service backups, created by the [Veeam Self-Service Portal (VSSP) for VCD](https://helpcenter.veeam.com/docs/backup/em/em_managing_vms_in_vcd_org.html?ver=110), or it can also include backups created directly on the backup server by the provider.

### Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

### How Has This Been Tested?

This script was tested in multiple labs where VCD backups were present.

### Checklist (check all applicable):

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in _hard to understand_ areas
* [x] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
