### PR TITLE
Adding Windows Defender information to Veeam backup job logs

### DIFF
--- a/BR-MPPreJobStatus/BR-MPPreJobModule.psm1
+++ b/BR-MPPreJobStatus/BR-MPPreJobModule.psm1
@@ -1,0 +1,253 @@
+# Johan Huttenga, 20220308
+
+$LogFile = "$($MyInvocation.MyCommand.Name).log"
+$CurrentPid = ([System.Diagnostics.Process]::GetCurrentProcess()).Id
+
+Function Write-Log {
+    param([string]$str, $consoleout = $true, $foregroundcolor = (get-host).ui.rawui.ForegroundColor, $backgroundcolor = (get-host).ui.rawui.BackgroundColor)      
+    if ($consoleout) { Write-Host -ForegroundColor $foregroundcolor -BackgroundColor $backgroundcolor $str }
+    $dt = (Get-Date).toString("yyyy.MM.dd HH:mm:ss")
+    $str = "[$dt] <$CurrentPid> $str"
+    Add-Content $LogFile -value $str
+}   
+
+Function Get-VBRInstallPath {
+    $uninstallinfo = Get-Item -Path "Registry::HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\{3A15F9E8-BD07-4A61-9A0D-C29B8369A662}"
+    return $uninstallinfo.GetValue("InstallLocation")
+}
+
+Function Get-VBRSessionTaskStatus {
+    param ($status)
+    [Veeam.Backup.Common.ETaskLogRecordStatus] $result = [Veeam.Backup.Common.ETaskLogRecordStatus]::ENone 
+    if ($status -eq "Warning") { $result = [Veeam.Backup.Common.ETaskLogRecordStatus]::EWarning }
+    elseif ($status -eq "Failed") { $result = [Veeam.Backup.Common.ETaskLogRecordStatus]::EFailed }
+    elseif ($status -eq "Success") { $result = [Veeam.Backup.Common.ETaskLogRecordStatus]::ESucceeded }
+    return $result
+}
+
+Function Write-VBRSessionLog {
+    param($session, $text, $status)
+    $task = New-VBRSessionTask $text -Status $status
+    $recordid = $session.Logger.AddLog($task)
+    $p = @{
+            'RecordId'=$recordid
+            'Task'=$task
+    }
+    $result = New-Object -TypeName PSObject -Prop $p
+    return $result
+}
+
+Function Update-VBRSessionTask {
+    param($session, $recordid, $text, $status)
+    $result = 0
+    if ($status -eq "Warning") {
+            $result = $session.Logger.UpdateWarning($recordid, $text)
+    }
+    elseif ($status -eq "Failed") {
+            $result = $session.Logger.UpdateErr($recordid, $text)
+    }
+    elseif ($status -eq "Success") {
+            $result = $session.Logger.UpdateSuccess($recordid, $text)
+    }
+    else {
+            $result = $session.Logger.UpdateLog($recordid, -1, $text, $null)
+    }
+}
+
+Function Complete-VBRSessionTask {
+    param($session, $cookie, $status)
+    $_status = Get-VBRSessionTaskStatus $status
+    $session.Logger.Complete($cookie,$_status)
+}
+
+Function New-VBRSessionTask {
+    param ($text, $status = "Success")
+    $_status = Get-VBRSessionTaskStatus $status
+    $cookie = [System.Guid]::NewGuid().ToString()
+    [Veeam.Backup.Common.CTaskLogRecord] $result = [Veeam.Backup.Common.CTaskLogRecord]::new($_status, [Veeam.Backup.Common.ETaskLogStyle]::ENone, 0, 0, $text, "", [System.DateTime]::Now, [System.DateTime]::Now, "", $cookie, 0)
+    return $result
+}
+
+Function Get-MPHealthState {
+    param($computerName = ".", $credential = $null)
+
+    $healthState = "Error"
+    $healthDetails = ""
+    
+    try {
+    
+        $s = $null
+        if ($null -eq $credential)
+        {
+            $s = Get-WmiObject -ClassName "MSFT_MpComputerStatus" -Namespace "root/microsoft/windows/defender" -ComputerName $computerName
+        }
+        else {
+            $s = Get-WmiObject -ClassName "MSFT_MpComputerStatus" -Namespace "root/microsoft/windows/defender" -ComputerName $computerName -Credential $credential
+        }
+        
+        if ($null -ne $s) {
+            #$p = Get-WmiObject -ClassName "MSFT_MpPreference" -Namespace "root\microsoft\windows\defender" -ComputerName $computerName
+            #todo: compare with defaults https://docs.microsoft.com/en-us/mem/intune/protect/antivirus-microsoft-defender-settings-windows
+            
+            $requiredAge = 2
+            $activeProtectionAvailable = (($s.OnAccessProtectionEnabled) -and ($s.RealTimeProtectionEnabled))
+            $requiredEnginesAvailable = (($s.IoavProtectionEnabled) -and ($s.BehaviorMonitorEnabled) -and ($s.AntivirusEnabled) -and ($s.AMServiceEnabled) -and ($s.AntispywareEnabled) -and ($s.NISEnabled))
+
+            $requiredEnginesUptoDate = (($s.AntivirusSignatureAge -le $requiredAge) -and ($s.AntispywareSignatureAge -le $requiredAge) -and ($s.NISSignatureAge -le $requiredAge))
+            
+            if ($activeProtectionAvailable -and $requiredEnginesAvailable -and $requiredEnginesUptoDate) {
+                if ([MP_COMPUTER_STATE].GetEnumName($s.ComputerState) -eq "Clean") {
+                $healthState = "Healthy"
+                }
+                else {
+                $healthState = "Warning"
+                }
+            }
+            elseif ($activeProtectionAvailable -and $requiredEnginesAvailable) {
+                $healthState = "Warning"
+                $healthDetails += "definitions are out of date, "
+            }
+            else {
+                $healthState = "Error"
+                if ($s.QuickScanAge -gt $requiredAge) { $healthDetails += " last quick scan was $($s.QuickScanAge) days ago, " }
+                if ($s.AntivirusSignatureAge -gt $requiredAge) { $healthDetails += " last antivirus signature update was $($s.AntivirusSignatureAge) days ago, " }
+                if ($s.AntispywareSignatureAge -gt $requiredAge) { $healthDetails += " last anti-spyware signature update was $($s.AntispywareSignatureAge) days ago, " }
+                if ($s.NISSignatureAge -gt $requiredAge) { $healthDetails += " last network inspection signature update was $($s.NISSignatureAge) days ago, " }
+            }
+            if ([MP_COMPUTER_STATE].GetEnumName($s.ComputerState) -ne "Clean") { $overallState += ", defender state is : $([MP_COMPUTER_STATE].GetEnumName($s.ComputerState))" }
+            $strNeedtoEnable = ""
+            if (!$s.RealTimeProtectionEnabled) { $strNeedtoEnable += "real-time protection, " }
+            if (!$s.OnAccessProtectionEnabled) { $strNeedtoEnable += "on-access protection, " }
+            if (!$s.IoavProtectionEnabled) { $strNeedtoEnable += "IOAV protection, " }
+            if (!$s.BehaviorMonitorEnabled) { $strNeedtoEnable += "behavior monitor, " }
+            if (!$s.AntiVirusEnabled) { $strNeedtoEnable += "antivirus, " }
+            if (!$s.AMServiceEnabled) { $strNeedtoEnable += "anti-malware service, " }
+            if (!$s.AntiSpywareEnabled) { $strNeedtoEnable += "anti-spyware, " }
+            if (!$s.NISEnabled) { $strNeedtoEnable += "network inspection, " }
+            if ($strNeedtoEnable.Length -gt 0) {
+                $healthDetails += ", need to enable $($strNeedtoEnable.TrimEnd(", "))"
+            }
+            if (!$s.IsTamperProtected) {
+                    $healthDetails += "recommend turning on tamper protection, "
+            }
+            if ($s.FullScanAge -gt 14 -or $null -ne $s.FullScanEndTime) {
+                    $healthDetails += "recommend running a full system scan, "
+            }
+            $computerNameResolved = $s.PSComputerName
+            $computerLastUpdated = $([array] $s.AntispywareSignatureAge,$s.AntispywareSignatureAge,$s.NISSignatureAge | measure -maximum).Maximum
+        }
+    }
+    catch {
+        $healthDetails += "$($_) $($_.ScriptStackTrace)".Replace("`r`n","")
+    }
+
+    $healthDetails = $healthDetails.TrimEnd(", ")
+    
+    if ($null -eq $computerNameResolved) { $computerNameResolved = $computerName }
+
+    if ($s -ne $null) {
+        Write-Log "{" 
+        Write-Log "`tComputer name : $($computerNameResolved), id : $($s.ComputerID)"
+        Write-Log "`tComputer state : $($s.ComputerState), $([MP_COMPUTER_STATE].GetEnumName($s.ComputerState))"
+        Write-Log "`tHealth state: $($healthState)"
+        Write-Log "`tHealth details: $($healthDetails)"
+        Write-Log "`tProduct version : $($s.AMProductVersion)"
+        Write-Log "`tService version : $($s.AMServiceVersion)"
+        Write-Log "`tEngine version : $($s.AMEngineVersion)"
+        Write-Log "`tAntivirus enabled : $($s.AntiVirusEnabled)"
+        Write-Log "`tAntimalware enabled : $($s.AMServiceEnabled)"
+        Write-Log "`tAntispyware enabled : $($s.AntispywareEnabled)"
+        Write-Log "`tNetwork inspection (NIS) enabled : $($s.NISEnabled)"
+        Write-Log "`tIOV protection enabled : $($s.IoavProtectionEnabled)"
+        Write-Log "`tBehavior monitor enabled : $($s.BehaviorMonitorEnabled)"
+        Write-Log "`tOn access protection enabled : $($s.OnAccessProtectionEnabled)"
+        Write-Log "`tReal time protection enabled : $($s.RealTimeProtectionEnabled)"
+        Write-Log "`tIs tamper protected : $($s.IsTamperProtected)"
+        Write-Log "`tQuick scan age : $($s.QuickScanAge)"
+        Write-Log "`tFull scan age : $($s.FullScanAge)"
+        Write-Log "`tAntivirus signature age : $($s.AntivirusSignatureAge), version : $($s.AntivirusSignatureVersion)"
+        Write-Log "`tAntispyware signature age : $($s.AntispywareSignatureAge), version : $($s.AntispywareSignatureVersion)"
+        Write-Log "`tNetwork inspection (NIS) signature age : $($s.NISSignatureAge), version : $($s.NISSignatureVersion)"
+        Write-Log "}" 
+    }
+    else {
+        Write-Log "{" 
+        Write-Log "`tComputer name: $($computerNameResolved)"
+        Write-Log "`tHealth state: $($healthState)"
+        Write-Log "`tHealth details: $($healthDetails)"
+        Write-Log "}" 
+    }
+    $p = @{
+            'ComputerName'=$computerNameResolved
+            'HealthState'=$healthState
+            'HealthDetails'=$healthDetails
+            'LastUpdated'= $computerLastUpdated
+    }
+    $result = New-Object -TypeName PSObject -Prop $p
+    return $result
+}
+
+enum MP_COMPUTER_STATE {
+  Clean = 0
+  PendingFullScan = 1
+  PendingReboot = 2
+  PendingManualSteps = 4
+  PendingOfflineScan = 8
+  PendingCriticalFailure = 16
+}
+
+Function Get-DnsInfo {
+  param($computerName)
+  
+  $hostnames = new-object System.Collections.Generic.HashSet[string]
+  $hostaddr = new-object System.Collections.Generic.HashSet[System.Net.IPAddress]
+
+  $entries = [System.Net.Dns]::GetHostEntry("$($computerName)")
+  foreach($e in $entries) {
+    foreach($a in $e.AddressList) {
+      try {
+        $s = [System.Net.Dns]::GetHostEntry($a)
+        $_ = $hostnames.Add($s.HostName)
+        foreach($i in $s.AddressList) {
+          $_ = $hostaddr.Add($i)
+        }
+      }
+      catch {}
+    }
+  }
+  $p = @{
+          'HostNames'=$hostnames
+          'AddressList'=$hostaddr
+  }
+  $result = New-Object -TypeName PSObject -Prop $p
+  return $result
+}
+
+function Find-VBRCredentials {
+  param($Filter, $FilterType)
+  
+  $credentials = Get-VBRCredentials
+  $result = @()
+  foreach($c in $credentials) {
+    if (($c.UserName -like $Filter -and $FilterType.ToLower() -eq "name") -or ($c.DomainName -like $Filter -and $FilterType.ToLower() -eq "domain")) { $userSelected = $true}
+    if ($null -eq $filter) { $userSelected = $true }
+    if ($userSelected) {
+        $cred = [veeam.backup.core.cdbcredentials]::Get([system.guid]::new("$($c.Id)"))
+        $pwd = $cred.Info.Credentials.GetEncryptedPassword()
+        $decoded = [Veeam.Backup.Common.CStringCoder]::Decode($pwd,$true)
+        if ($decoded.Length -gt 0) {
+            $secpwd = ConvertTo-SecureString $decoded -AsPlainText -Force
+        }
+        $p = @{
+          'Username'=$cred.Info.Credentials.UserName
+          'UsernameAtNotation'=$cred.Info.Credentials.UserNameAtNotation
+          'UsernameSlashNotation'=$cred.Info.Credentials.UserNameSlashNotation
+          'Password'= $secpwd
+        }
+        $result += New-Object -TypeName PSObject -Prop $p
+    }
+  }
+  return $result
+}
+
+Export-ModuleMember -Function Write-Log, Get-VBRSessionTaskStatus, Write-VBRSessionLog, Update-VBRSessionTask, Complete-VBRSessionTask, New-VBRSessionTask, Get-MPHealthState, Find-VBRCredentials, Get-VBRCredentials, Get-DecryptedString, Get-DnsInfo

--- a/BR-MPPreJobStatus/BR-MPPreJobStatus.ps1
+++ b/BR-MPPreJobStatus/BR-MPPreJobStatus.ps1
@@ -1,0 +1,93 @@
+# Johan Huttenga, 20220308
+
+Param([string] $JobId, [string] $SessionId)
+
+$Version = "0.0.0.1"
+
+$ImportFunctions = { 
+      Import-Module Veeam.Backup.PowerShell
+      Import-Module "C:\Scripts\BR-MPPreJobStatus\BR-MPPreJobModule.psm1" -Force > $null
+}
+
+Invoke-Command -ScriptBlock $ImportFunctions -NoNewScope
+
+Write-Log $("="*78)
+Write-Log "{"
+Write-Log "`tScript: $($MyInvocation.MyCommand.Name)"
+Write-Log "`tVersion: { $($Version) }"
+Write-Log "}"
+
+# attaching to Veeam Backup and Replication job
+
+# load necessary objects in memory
+$servers = Get-VBRServer
+
+$job = [Veeam.Backup.Core.CBackupJob]::Get([System.Guid]::new($jobid))
+if ($job -eq $null) { Write-Log "Error: Cannot continue. Job ($($jobid)) not found."; return }
+
+$session = [Veeam.Backup.Core.CBackupSession]::Get([System.Guid]::new($sessionid))
+if ($session -eq $null) { Write-Log "Error: Cannot continue. Session ($($sessionid)) not found."; return }
+
+Write-Log "Attaching to $($job.Name) ($($jobid)) session ($($sessionid))."
+$taskinfo = Write-VBRSessionLog -Session $session -Text "Executing pre-job script: Child script running in background."
+
+# getting health status per machine in job and outputing to job session log
+$objects = $job.GetObjectsInJob() # could also use vioijs / hvoijs / desktopoijs
+
+$output = "Getting Windows Defender health state for objects in job."
+Write-Log $output
+Update-VBRSessionTask -Session $session -RecordId $taskinfo[0].RecordId -Text "Executing pre-job script: $($output)" -Status "None"
+$taskstatus = "Success"
+$taskstatustext = ""
+try {
+  foreach($o in $objects) { 
+    $dnsinfo = Get-DnsInfo $o.Name 
+    if ($null -ne $dnsinfo) {
+      
+      $localDomain = $(Get-WmiObject -Namespace root\cimv2 -Class Win32_ComputerSystem | Select Domain).Domain
+      
+      # pick first fqdn available if possible
+      $computerName = $o.Name
+      $computerHasLocalDomain = $false
+
+      foreach($hn in $dnsinfo.HostNames) { if ($hn.ToLower().Contains($localDomain.ToLower())) { $computerHasLocalDomain = $true; $computerName = $hn; break; } }
+      if(!$computerHasLocalDomain) { foreach($hn in $dnsinfo.HostNames) { if ($hn.Contains(".")) { $computerName = $hn; break; } } }
+
+      $_substatus = "Failed"
+      $_substatustext = "" 
+      if ($computerName -eq "." -or $computerName -eq "localhost") {
+        $h = Get-MPHealthState -ComputerName $computerName
+      }
+      else
+        {
+          # see if there is a stored credential we can access
+          $domain = $computerName.Split('.')[1]
+          if ($null -eq $domain -or $domain.Length -eq 0) { # cannot find domain associated
+            $domain = $localDomain # try with local domain credentials
+          }
+          $creds = Find-VBRCredentials -Filter $domain -FilterType "Domain"
+          if ($null -ne $creds) {
+            $c = New-Object System.Management.Automation.PSCredential ($creds[0].UserName, $creds[0].Password) 
+            $h = Get-MPHealthState -ComputerName $computerName -Credential $c
+          }
+          else {
+            $_substatustext = "$($computerName): Cannot find valid credentials to use. Did not query Windows Defender status."
+            Write-Log $_substatustext
+          }
+        }
+      }
+      if ($h.healthState -eq "Healthy") { $_substatus = "Success" }
+      if ($h.healthState -eq "Warning") { $_substatus = "Warning" }
+      if ($_substatustext.Length -eq 0) { $_substatustext = "$($h.computerName): Windows Defender status is '$($h.healthState)', last updated $($h.lastUpdated) days ago, $($h.healthDetails)" }
+      Write-VBRSessionLog -Session $session -Text $_substatustext -Status $_substatus
+    }
+  $taskstatustext ="Executing pre-job script completed: Retrieved Windows Defender health state for objects in job."
+}
+catch {
+  $taskstatus = "Failed"
+  $taskerror = $_
+  $taskstacktrace = $_.ScriptStackTrace.Replace("`r`n","")
+  $taskstatustext = "Executing pre-job script failed with error: $($taskerror) $($taskstacktrace)"
+}
+
+Update-VBRSessionTask -Session $session -RecordId $taskinfo.RecordId -Text $taskstatustext -Status $taskstatus

--- a/BR-MPPreJobStatus/BR-MPPreJobWatch.ps1
+++ b/BR-MPPreJobStatus/BR-MPPreJobWatch.ps1
@@ -1,0 +1,31 @@
+# Johan Huttenga, 20220308
+
+$parentpid = (Get-WmiObject Win32_Process -Filter "processid='$pid'").parentprocessid.ToString()
+$parentcmd = (Get-WmiObject Win32_Process -Filter "processid='$parentpid'").CommandLine
+if ($parentcmd) { $parentcmds = $parentcmd.Split('"') }
+if (($parentcmds) -and ($parentcmds.length -ge 11)) {
+  $jobid = $parentcmds[9]; $sessionid = $parentcmds[11]
+} else {
+  Write-Host -ForegroundColor red -BackgroundColor black "Error: This script was called outside of a Veeam Backup & Replication job. Cannot continue."
+  return
+}
+
+$LogFile = "$($MyInvocation.MyCommand.Name).log"
+$CurrentPid = ([System.Diagnostics.Process]::GetCurrentProcess()).Id
+
+Function Write-Log {
+    param([string]$str, $consoleout = $true, $foregroundcolor = (get-host).ui.rawui.ForegroundColor, $backgroundcolor = (get-host).ui.rawui.BackgroundColor)      
+    if ($consoleout) { Write-Host -ForegroundColor $foregroundcolor -BackgroundColor $backgroundcolor $str }
+    $dt = (Get-Date).toString("yyyy.MM.dd HH:mm:ss")
+    $str = "[$dt] <$CurrentPid> $str"
+    Add-Content $LogFile -value $str
+}   
+
+try {
+  Write-Log "Starting C:\Scripts\BR-MPPreJobStatus\BR-MPPreJobStatus.ps1 -JobId $($jobid) -SessionId $($sessionid) ..."
+  Start-Process "powershell.exe" -ArgumentList "C:\Scripts\BR-MPPreJobStatus\BR-MPPreJobStatus.ps1 -JobId $jobid -SessionId $sessionid" -WorkingDirectory "C:\Scripts\BR-MPPreJobStatus"
+}
+catch {
+  Write-Log "Error has occurred: $($_) $($_.ScriptStackTrace)"
+  exit 1
+}

--- a/BR-MPPreJobStatus/README.md
+++ b/BR-MPPreJobStatus/README.md
@@ -1,0 +1,28 @@
+# Get Windows Defender Status of VMs in Veeam Backup Job
+## VeeamHub
+Veeamhub projects are community driven projects, and are not created by Veeam R&D nor validated by Veeam Q&A. They are maintained by community members which might be or not be Veeam employees. 
+
+## Distributed under MIT license
+Copyright (c) 2022 VeeamHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## Project Notes
+**Author:** Johan Huttenga (@johanhuttenga)
+
+**Version:** 0.0.0.1
+
+**Function:** Starts a PowerShell background process that watches a Veeam Backup Job. This in turn runs a process that gets the Windows Defender Status of the VMs in the job. In total this consists of three parts:
+
+1. BR-MPPreJobWatch which is added as a pre-job script to a Backup Job
+2. BR-MPPreJobStatus which gets the Windows Defender status via WMI for each VM in the backup job.
+3. BR-MPPreJobModule which contains all the dependencies required.
+
+**Requires:** Script supports Windows only and requires Veeam Backup & Replication v11 or higher.  Credentials have to be available for the machines in the job. These scripts all run in a different user space associated with the Veeam service account, which means certain defaults have to be set correctly.
+
+**Usage:**
+Add BR-MPPreJobWatch as pre-job script to Veeam Failover Plan. No parameters required.


### PR DESCRIPTION
# Pull Request Template

By contributing, you agree that your contributions will be licensed under the projects original open source license.

## Description

Adding a new script that supports getting the Windows Defender status for VMs before/during backup job run. https://www.dropbox.com/s/ln6ld6gw29g3nic/VBR-Windows-Defender-20220308.mp4?dl=0

Fixes # (issue)

### Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [X] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How Has This Been Tested?

Tested on my machine. Requires scripts to be put in C:\Scripts\BR-MPPreJobStatus\ directory. 

### Checklist (check all applicable):

* [X] My code follows the style guidelines of this project
* [X] I have performed a self-review of my own code
* [X] I have commented my code, particularly in _hard to understand_ areas
* [X] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
